### PR TITLE
Code must be int

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -159,7 +159,7 @@ class Query implements \JsonSerializable
         try {
             return $this->resolveCollection($this->subject->get());
         } catch (\Exception $e) {
-            throw new QueryException($e->getMessage(), $e->getCode(), $e);
+            throw new QueryException($e->getMessage(), (int)$e->getCode(), $e);
         }
     }
 


### PR DESCRIPTION
Als exception komt, krijg je hier foutmelding.
Moet int zijn, maar t returned string.
Bij deze een cast toegevoegd.