### PR TITLE
crs-13161

### DIFF
--- a/src/Traits/FilterTrait.php
+++ b/src/Traits/FilterTrait.php
@@ -131,7 +131,7 @@ trait FilterTrait
             /**
              * @var string $column
              * @var string $operator
-             * @var string|array $value
+             * @var string|array|null $value
              * @var string $lambda
              * @var string $relation
              */
@@ -252,12 +252,12 @@ trait FilterTrait
      *
      * @param string $column
      * @param string $operator
-     * @param string|array<int<0, max>, string> $value
+     * @param string|array<int<0, max>, string>|null $value
      * @param Builder<TModelClass> $builder
      * @return bool
      * @throws \ReflectionException
      */
-    private function isValidFilter(string $column, string $operator, string|array $value, Builder $builder): string|bool
+    private function isValidFilter(string $column, string $operator, string|array|null $value, Builder $builder): string|bool
     {
         if (empty($column) || empty($operator)) {
             return false;
@@ -330,7 +330,7 @@ trait FilterTrait
      *
      * @param string $input
      * @param bool $inverseOperator
-     * @return array{string, string, array<int, string>|string, ''|'all'|'any', string}
+     * @return array{string, string, array<int, string>|string|null, ''|'all'|'any', string}
      * @throws \Exception
      */
     private function splitInput(string $input, bool $inverseOperator = false): array

--- a/src/Utils/OperatorUtils.php
+++ b/src/Utils/OperatorUtils.php
@@ -86,7 +86,7 @@ class OperatorUtils
      * @return string|array<int, string> The processed value
      * @throws \InvalidArgumentException If the operator is not found in the map
      */
-    public static function getValueBasedOnOperator(string $odataOperator, string|array $value): string|array
+    public static function getValueBasedOnOperator(string $odataOperator, string|array|null $value): string|array|null
     {
         if (!self::isValidOperator($odataOperator)) {
             throw new \InvalidArgumentException("Invalid operator: {$odataOperator}");
@@ -97,11 +97,15 @@ class OperatorUtils
             return $value;
         }
 
+        if ($value === 'null') {
+            return null;
+        }
+
         $stringValue = addslashes(is_array($value) ? implode(',', $value) : (string)$value);
         if (isset(self::$operatorMap[$odataOperator][2])) {
             return str_replace('{$value}', $stringValue, self::$operatorMap[$odataOperator][2]);
         }
-        
+
         return $stringValue;
     }
 }


### PR DESCRIPTION
Wanneer er gefiltered werd op een null in een kolom. Werd deze door de oData niet correct vertaald.
Doordat deze als 'null' werd meegegeven kon laravel er niet correct op filteren. Gezorgd dat als er nu een 'null' gezien wordt, dat deze als null gereturned wordt, waardoor wel correct gefiltered kan worden.