### PR TITLE
crs-13166

### DIFF
--- a/src/Traits/ExpandTrait.php
+++ b/src/Traits/ExpandTrait.php
@@ -132,6 +132,9 @@ trait ExpandTrait
         } elseif (Str::startsWith(strtolower($option), '$filter=')) {
             $value = substr($option, strlen('$filter='));
             $this->handleFilter($builder, $value);
+        } elseif (Str::startsWith(strtolower($option), '$orderby=')) {
+            $value = substr($option, strlen('$orderby='));
+            $this->handleOrderBy($builder, $value);
         } elseif (Str::startsWith(strtolower($option), '$expand=')) {
             $value = substr($option, strlen('$expand='));
 

--- a/tests/Feature/OrderByTest.php
+++ b/tests/Feature/OrderByTest.php
@@ -15,4 +15,15 @@ it('Runs orderby', function (?string $orderby, string $result) {
     "Order by test1 desc, test2 desc" => ["test1 desc, test2 desc", 'select * from "test_models" order by "test1" desc, "test2" desc limit 100 offset 0'],
 ]);
 
+it('Runs orderby in expand', function () {
+    $query = createQueryFromParams(expand: 'RelatedModel($orderby=name asc)');
+    $sql = $query->toSql();
+    
+    // Debug: Let's see what the actual SQL looks like
+    dump($sql);
+    
+    // The SQL should contain an ORDER BY clause for the related model
+    expect($sql)->toContain('order by "name" asc');
+});
+
 


### PR DESCRIPTION
Wanneer er in een query een orderBy wordt meegegeven dan wordt deze niet correct op de model geplaatst.

Cursor heeft het probleem gevonden aan de hand van opgegeven query en resultaat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for using the `$orderby` option within expand clauses, allowing users to specify the order of related data.
- **Tests**
	- Introduced a new test to verify that ordering works correctly within expanded related models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->