### PR TITLE
crs-13255

### DIFF
--- a/src/Utils/StringUtils.php
+++ b/src/Utils/StringUtils.php
@@ -19,14 +19,60 @@ class StringUtils
      */
     public static function splitODataExpression(string $expression, string $separator = ','): array
     {
-        $results = [];
-        $current = '';
-        $depth = 0;
+        $results   = [];
+        $current   = '';
+        $depth     = 0;
+
+        // Quote-handling state
+        $inQuote   = false;   // Whether we are currently inside a quoted literal
+        $quoteChar = null;    // Which quote char opened the literal (' or ")
 
         $length = strlen($expression);
         for ($i = 0; $i < $length; $i++) {
             $char = $expression[$i];
 
+            if ($char === "'" || $char === '"') {
+                // Determine if this quote char is escaped. Two mechanisms considered:
+                //   1. A backslash before the quote (e.g. \")
+                //   2. The OData style doubled quote inside a literal (e.g. '' inside 'don''t')
+
+                $isEscapedByBackslash = $i > 0 && $expression[$i - 1] === '\\';
+
+                if ($inQuote) {
+                    if ($char === $quoteChar && ! $isEscapedByBackslash) {
+                        // Check for doubled quote escaping within OData literals.
+                        if ($i + 1 < $length && $expression[$i + 1] === $quoteChar) {
+                            // It's an escaped quote – keep both quotes to preserve the literal.
+                            $current .= $char . $quoteChar;
+                            $i++; // Skip the second quote in the pair
+                            continue;
+                        }
+
+                        // Otherwise this is the closing quote of the literal
+                        $inQuote   = false;
+                        $quoteChar = null;
+                    }
+                } else {
+                    if (! $isEscapedByBackslash) {
+                        // Opening a new quoted literal
+                        $inQuote   = true;
+                        $quoteChar = $char;
+                    }
+                }
+
+                // In all cases, include the quote character in the token
+                $current .= $char;
+                continue;
+            }
+
+            // While inside a quoted literal treat every character as data – parentheses and
+            // separators included – and move on.
+            if ($inQuote) {
+                $current .= $char;
+                continue;
+            }
+
+            // Structural parentheses tracking (only when *not* inside quotes)
             if ($char === '(') {
                 $depth++;
             } elseif ($char === ')') {
@@ -37,12 +83,18 @@ class StringUtils
                 throw new \InvalidArgumentException('Unbalanced parentheses in OData expression');
             }
 
+            // Split at the top-level separator (outside parentheses & quotes)
             if ($char === $separator && $depth === 0) {
                 $results[] = $current;
-                $current = '';
+                $current   = '';
             } else {
                 $current .= $char;
             }
+        }
+
+        if ($inQuote) {
+            // A quote was opened but never closed.
+            throw new \InvalidArgumentException('Unbalanced quotes in OData expression');
         }
 
         if ($depth !== 0) {


### PR DESCRIPTION
Asked cursor to solve the problem of receiving a '&' or '(' in the filter query.
Originally, oData put in the query as an extension or opening or closing because the parenthesis weren't correct.

Now it keeps better track of the parenthesis and makes sure the received '&' or '(' in the filter, are actually used as filter param.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of quoted literals in OData expressions, preventing incorrect splitting inside quotes and ensuring proper parsing of escaped quotes.
  * Added detection for unbalanced quotes, providing clearer error feedback for malformed expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->