### PR TITLE
crs-13509

### DIFF
--- a/src/Traits/FilterTrait.php
+++ b/src/Traits/FilterTrait.php
@@ -341,7 +341,7 @@ trait FilterTrait
         // 3. String literals enclosed in single quotes
         // 4. Numeric values
         // 5. Field names or identifiers
-        $pattern = '/\b(contains|startswith|endswith|and|or|not|eq|ne|gt|ge|lt|le|in)\b|([(),])|\'([^\']*)\'|(\d+(\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)/i';
+        $pattern = '/\b(contains|startswith|endswith|and|or|not|eq|ne|gt|ge|lt|le|in)\b|([(),])|\'([^\']*)\'|(-?\d+(\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)/i';
         $lambda = '';
         $relation = '';
         // Perform global matching


### PR DESCRIPTION
Probleem was dat zodra je iets uit de database wilt halen met een filter dat een waarde heeft van een min getal dan wordt de min verwijderd dus eigenlijk een absolute waarde.

Deze aanpassing is nodig voor het ophalen van templates waar company_id eq -1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter input handling to correctly recognize and process negative numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->