### PR TITLE
Fix literal 0 in $filter expressions

### DIFF
--- a/src/Traits/FilterTrait.php
+++ b/src/Traits/FilterTrait.php
@@ -357,7 +357,8 @@ trait FilterTrait
             } elseif (!empty($match[3])) {
                 // String literals without quotes
                 return $match[3];
-            } elseif (!empty($match[4])) {
+            } elseif (($match[4] ?? '') !== '') {
+                // Dont't use empty here because empty('0') = true!
                 $token = $match[4];
                 // Numeric or date/time value.
                 if (preg_match('/^\d+(\.\d+)?$/', $token, $_) && is_numeric($token)) {

--- a/tests/Feature/FilterTest.php
+++ b/tests/Feature/FilterTest.php
@@ -25,6 +25,7 @@ it('Run filter', function (?string $filter, string $result) {
     "Two filters with all filter" => ["name eq 'Aqqo' and relatedModels/all(f:f/cost gt 10)", 'select * from "test_models" where (("test_models"."name" = \'Aqqo\') and (not exists (select * from "related_models" where "test_models"."id" = "related_models"."test_model_id" and "related_models"."cost" <= \'10\'))) limit 100 offset 0'],
     "Two filters with all filter but inversed" => ["relatedModels/all(f:f/cost gt 10) and name eq 'Aqqo'", 'select * from "test_models" where ((not exists (select * from "related_models" where "test_models"."id" = "related_models"."test_model_id" and "related_models"."cost" <= \'10\')) and ("test_models"."name" = \'Aqqo\')) limit 100 offset 0'],
     "Two filters with all filter but not expandable" => ["nonExistingModel/all(f:f/cost gt 10) and name eq 'Aqqo'", 'select * from "test_models" where (("test_models"."name" = \'Aqqo\')) limit 100 offset 0'],
+    "0 literal" => ["id eq 0", 'select * from "test_models" where "test_models"."id" = \'0\' limit 100 offset 0'],
 ]);
 
 // See https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_PrimitiveLiterals
@@ -50,5 +51,3 @@ it('Handle dateTimeOffset literals', function (?string $filter, string $result) 
     // Same as in 'Run filter', but now as dateTimeOffset literal (instead of string)
     "Grouped filter" => ["(start_datetime_utc gt 2024-05-13T06:00:00+00:00 or start_datetime_utc lt 2024-05-13T06:00:00+00:00) and end_datetime_utc lt 2024-05-19T15:00:00+00:00", 'select * from "test_models" where (("test_models"."start_datetime_utc" > \'2024-05-13T06:00:00+00:00\' or "test_models"."start_datetime_utc" < \'2024-05-13T06:00:00+00:00\') and ("test_models"."end_datetime_utc" < \'2024-05-19T15:00:00+00:00\')) limit 100 offset 0'],
 ]);
-
-

--- a/tests/Unit/FilterTest.php
+++ b/tests/Unit/FilterTest.php
@@ -230,7 +230,7 @@ it('can handle empty value for non-IN operators', function () {
 
 it('can handle zero value for non-IN operators', function () {
     $models = createQueryFromParams(filter: "id eq 0")->get();
-    expect($models)->toHaveCount(5); // Zero value should return all results
+    expect($models)->toHaveCount(0); // Zero value should return no results
 });
 
 it('can handle non-filterable properties', function () {


### PR DESCRIPTION
"$filter=is_deleted eq 0" gaf ook resultaten met is_deleted=1 terug. Dat is nu opgelost.