### PR TITLE
CRS-16220: Runtime OData projection for MorphTo / expanded relations

### DIFF
--- a/database/factories/RelatedModelFactory.php
+++ b/database/factories/RelatedModelFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Aqqo\OData\Database\Factories;
+
+use Aqqo\OData\Tests\Testclasses\RelatedModel;
+use Aqqo\OData\Tests\Testclasses\TestModel;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RelatedModel>
+ */
+class RelatedModelFactory extends Factory
+{
+    protected $model = RelatedModel::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'test_model_id' => TestModel::factory(),
+            'name' => $this->faker->name(),
+            'full_name' => $this->faker->optional()->name(),
+            'cost' => $this->faker->optional()->numberBetween(0, 1000),
+        ];
+    }
+}

--- a/src/Query.php
+++ b/src/Query.php
@@ -242,8 +242,11 @@ class Query implements \JsonSerializable
     }
 
     /**
-     * For expanded relations (MorphTo, pivot, etc.): honor nested $select when present, otherwise
-     * default-selectable OData fields for the concrete model, else raw attributes.
+     * For expanded relations (MorphTo, pivot, etc.): whitelist-only serialization.
+     *
+     * Uses the nested $select map when non-empty, otherwise default-selectable #[ODataProperty]
+     * fields for the concrete model. If neither yields keys (e.g. unannotated morph target),
+     * returns an empty array — never raw DB attributes.
      *
      * @return array<string, mixed>
      */
@@ -256,6 +259,6 @@ class Query implements \JsonSerializable
 
         $default = $this->getRuntimeDefaultSelectedAttributesForModel($item);
 
-        return $default !== [] ? $default : $item->getAttributes();
+        return $default !== [] ? $default : [];
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -18,7 +18,6 @@ use Aqqo\OData\Traits\OrderByTrait;
 use Aqqo\OData\Traits\SkipTrait;
 use Aqqo\OData\Traits\TopTrait;
 use Aqqo\OData\Traits\ResponseTrait;
-use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 /**
  * @template TModelClass of Model
@@ -190,17 +189,14 @@ class Query implements \JsonSerializable
      * therefor an infinite loop is introduced.
      *
      * @param Model $item
-     * @param bool $ignore_selects
      * @return array
      */
-    private function resolveModel(Model &$item, bool $ignore_selects = false): array
+    private function resolveModel(Model &$item): array
     {
         // First we clone the item. As the getAttribute might load extra relations we do not want.
         $cloned_item = clone $item;
 
-        $attributes = $ignore_selects
-            ? $this->resolveAttributesWithRuntimeODataFallback($item)
-            : $this->resolveAttributesFromSelectMap($item);
+        $attributes = $this->resolveAttributesWithRuntimeODataFallback($item);
 
         // Then set the attribute on the clonedItem
         $cloned_item->setRawAttributes($attributes);
@@ -208,21 +204,7 @@ class Query implements \JsonSerializable
             if ($relation instanceof Collection) {
                 $attributes[$key] = $this->resolveCollection($relation);
             } else if ($relation instanceof Model)  {
-                $reflectionClass = new \ReflectionClass($item);
-
-                if ($reflectionClass->hasMethod($key)) {
-                    $method = $reflectionClass->getMethod($key);
-                    $returnType = $method->getReturnType();
-
-                    if ($returnType && $returnType->getName() == MorphTo::class) {
-                        $attributes[$key] = $this->resolveModel($relation, true);
-                    } else {
-                        $attributes[$key] = $this->resolveModel($relation);
-                    }
-                } else {
-                    // Handle relations like BelongsToMany pivot without defined accessors on the model.
-                    $attributes[$key] = $this->resolveModel($relation, true);
-                }
+                $attributes[$key] = $this->resolveModel($relation);
             }
         }
         return $attributes;

--- a/src/Query.php
+++ b/src/Query.php
@@ -198,14 +198,9 @@ class Query implements \JsonSerializable
         // First we clone the item. As the getAttribute might load extra relations we do not want.
         $cloned_item = clone $item;
 
-        $attributes = [];
-        if ($ignore_selects) {
-            $attributes = $item->getAttributes();
-        } else {
-            foreach ($this->selects[ClassUtils::getShortName($item)] ?? [] as $odata_column => $db_column) {
-                $attributes[$odata_column] = $item->getAttribute($db_column);
-            }
-        }
+        $attributes = $ignore_selects
+            ? $this->resolveAttributesWithRuntimeODataFallback($item)
+            : $this->resolveAttributesFromSelectMap($item);
 
         // Then set the attribute on the clonedItem
         $cloned_item->setRawAttributes($attributes);
@@ -231,5 +226,36 @@ class Query implements \JsonSerializable
             }
         }
         return $attributes;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resolveAttributesFromSelectMap(Model $item): array
+    {
+        $attributes = [];
+        foreach ($this->selects[ClassUtils::getShortName($item)] ?? [] as $odata_column => $db_column) {
+            $attributes[$odata_column] = $item->getAttribute($db_column);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * For expanded relations (MorphTo, pivot, etc.): honor nested $select when present, otherwise
+     * default-selectable OData fields for the concrete model, else raw attributes.
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveAttributesWithRuntimeODataFallback(Model $item): array
+    {
+        $selected = $this->resolveAttributesFromSelectMap($item);
+        if ($selected !== []) {
+            return $selected;
+        }
+
+        $default = $this->getRuntimeDefaultSelectedAttributesForModel($item);
+
+        return $default !== [] ? $default : $item->getAttributes();
     }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -177,8 +177,19 @@ class Query implements \JsonSerializable
      */
     private function resolveCollection(Collection $collection): \Illuminate\Support\Collection
     {
-        return $collection->map(function ($item) {
+        return $collection->map(function (Model $item): array {
             return $this->resolveModel($item);
+        });
+    }
+
+    /**
+     * @param Collection<int, TModelClass> $collection
+     * @return \Illuminate\Support\Collection<int, array<string,mixed>>
+     */
+    private function resolveCollectionForRelation(Collection $collection, string $relationName): \Illuminate\Support\Collection
+    {
+        return $collection->map(function (Model $item) use ($relationName): array {
+            return $this->resolveModel($item, $relationName);
         });
     }
 
@@ -189,34 +200,71 @@ class Query implements \JsonSerializable
      * therefor an infinite loop is introduced.
      *
      * @param Model $item
-     * @return array
+     * @return array<string, mixed>
      */
-    private function resolveModel(Model &$item): array
+    private function resolveModel(Model &$item, ?string $expandedAsRelation = null): array
     {
         // First we clone the item. As the getAttribute might load extra relations we do not want.
         $cloned_item = clone $item;
 
-        $attributes = $this->resolveAttributesWithRuntimeODataFallback($item);
+        $attributes = $this->resolveAttributesWithRuntimeODataFallback($item, $expandedAsRelation);
 
         // Then set the attribute on the clonedItem
         $cloned_item->setRawAttributes($attributes);
         foreach ($cloned_item->getRelations() as $key => $relation) {
             if ($relation instanceof Collection) {
-                $attributes[$key] = $this->resolveCollection($relation);
+                $attributes[$key] = $this->resolveCollectionForRelation($relation, $key);
             } else if ($relation instanceof Model)  {
-                $attributes[$key] = $this->resolveModel($relation);
+                $attributes[$key] = $this->resolveModel($relation, $key);
             }
         }
         return $attributes;
     }
 
     /**
-     * @return array<string, mixed>
+     * Resolves attributes from nested $expand $select tokens (see {@see SelectTrait::$nestedExpandExplicitSelectTokens})
+     * when serializing that relation, otherwise from {@see SelectTrait::$selects} for this model's short name.
+     *
+     * - `null` — no applicable select map for this serialization context; caller may use runtime default OData properties.
+     * - `[]` — nested $select was applied but mapped to no fields (explicit empty whitelist).
+     * - non-empty — mapped projection.
+     *
+     * @return array<string, mixed>|null
      */
-    private function resolveAttributesFromSelectMap(Model $item): array
+    private function resolveAttributesFromSelectMap(Model $item, ?string $expandedAsRelation = null): ?array
     {
+        if ($expandedAsRelation !== null && array_key_exists($expandedAsRelation, $this->nestedExpandExplicitSelectTokens)) {
+            $tokens = $this->nestedExpandExplicitSelectTokens[$expandedAsRelation];
+            $mapped = [];
+            foreach ($tokens as $token) {
+                $dbColumn = $this->getSelectableDbColumnForConcreteModel($item, $token);
+                if ($dbColumn !== false) {
+                    $mapped[$token] = $dbColumn;
+                }
+            }
+            if ($mapped === []) {
+                return [];
+            }
+            $attributes = [];
+            foreach ($mapped as $odata_column => $db_column) {
+                $attributes[$odata_column] = $item->getAttribute($db_column);
+            }
+
+            return $attributes;
+        }
+
+        $shortName = ClassUtils::getShortName($item);
+        if (! array_key_exists($shortName, $this->selects)) {
+            return null;
+        }
+
+        $map = $this->selects[$shortName];
+        if ($map === []) {
+            return [];
+        }
+
         $attributes = [];
-        foreach ($this->selects[ClassUtils::getShortName($item)] ?? [] as $odata_column => $db_column) {
+        foreach ($map as $odata_column => $db_column) {
             $attributes[$odata_column] = $item->getAttribute($db_column);
         }
 
@@ -232,15 +280,15 @@ class Query implements \JsonSerializable
      *
      * @return array<string, mixed>
      */
-    private function resolveAttributesWithRuntimeODataFallback(Model $item): array
+    private function resolveAttributesWithRuntimeODataFallback(Model $item, ?string $expandedAsRelation = null): array
     {
-        $selected = $this->resolveAttributesFromSelectMap($item);
-        if ($selected !== []) {
-            return $selected;
+        $selected = $this->resolveAttributesFromSelectMap($item, $expandedAsRelation);
+        if ($selected === null) {
+            $default = $this->getRuntimeDefaultSelectedAttributesForModel($item);
+
+            return $default !== [] ? $default : [];
         }
 
-        $default = $this->getRuntimeDefaultSelectedAttributesForModel($item);
-
-        return $default !== [] ? $default : [];
+        return $selected;
     }
 }

--- a/src/Traits/AttributesTrait.php
+++ b/src/Traits/AttributesTrait.php
@@ -131,6 +131,7 @@ trait AttributesTrait
      * Build OData-shaped attributes for a loaded model using default-selectable #[ODataProperty] metadata.
      *
      * Used when serializing expanded relations (e.g. MorphTo) where the concrete type is only known at runtime.
+     * Models without such metadata return an empty array from here; callers must not fall back to raw attributes.
      *
      * @return array<string, mixed>
      */

--- a/src/Traits/AttributesTrait.php
+++ b/src/Traits/AttributesTrait.php
@@ -30,6 +30,11 @@ trait AttributesTrait
     private $expandables = [];
 
     /**
+     * @var array<class-string<Model>, array<int, array{odata_column: string, source: string|null, resolver_method: string|null}>>
+     */
+    private array $runtimeDefaultSelectedAttributeDefinitions = [];
+
+    /**
      * @return void
      * @throws \ReflectionException
      */
@@ -138,6 +143,31 @@ trait AttributesTrait
     protected function getRuntimeDefaultSelectedAttributesForModel(Model $item): array
     {
         $attributes = [];
+        $modelClass = $item::class;
+
+        if (! array_key_exists($modelClass, $this->runtimeDefaultSelectedAttributeDefinitions)) {
+            $this->runtimeDefaultSelectedAttributeDefinitions[$modelClass] = $this->buildRuntimeDefaultSelectedAttributeDefinitions($item);
+        }
+
+        foreach ($this->runtimeDefaultSelectedAttributeDefinitions[$modelClass] as $definition) {
+            $db_column = $definition['source'] ?? $definition['odata_column'];
+            if ($definition['resolver_method'] !== null) {
+                $db_column = $item->{$definition['resolver_method']}();
+            }
+
+            $odata_column = $definition['odata_column'];
+            $attributes[$odata_column] = $item->getAttribute($db_column);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @return array<int, array{odata_column: string, source: string|null, resolver_method: string|null}>
+     */
+    protected function buildRuntimeDefaultSelectedAttributeDefinitions(Model $item): array
+    {
+        $definitions = [];
         $reflectionClass = new \ReflectionClass($item);
 
         foreach ($this->getODataPropertyAttributes($reflectionClass) as $attribute) {
@@ -148,18 +178,22 @@ trait AttributesTrait
                 continue;
             }
 
-            $odata_column = $instance->getName();
-            $db_column = $instance->getSource() ?? $instance->getName();
-
-            $resolver_method = 'oData'.ucfirst($instance->getName()).'Resolver';
-            if (empty($instance->getSource()) && method_exists($item, $resolver_method)) {
-                $db_column = $item->{$resolver_method}();
+            $resolver_method = null;
+            if (empty($instance->getSource())) {
+                $candidateResolver = 'oData'.ucfirst($instance->getName()).'Resolver';
+                if (method_exists($item, $candidateResolver)) {
+                    $resolver_method = $candidateResolver;
+                }
             }
 
-            $attributes[$odata_column] = $item->getAttribute($db_column);
+            $definitions[] = [
+                'odata_column' => $instance->getName(),
+                'source' => $instance->getSource(),
+                'resolver_method' => $resolver_method,
+            ];
         }
 
-        return $attributes;
+        return $definitions;
     }
 
     /**

--- a/src/Traits/AttributesTrait.php
+++ b/src/Traits/AttributesTrait.php
@@ -108,7 +108,7 @@ trait AttributesTrait
      * @param \ReflectionClass<object> $reflectionClass
      * @return array<int, \ReflectionAttribute>
      */
-    private function getODataPropertyAttributes(\ReflectionClass $reflectionClass): array
+    protected function getODataPropertyAttributes(\ReflectionClass $reflectionClass): array
     {
         $class_hierarchy = [];
         $current = $reflectionClass;
@@ -122,6 +122,40 @@ trait AttributesTrait
             foreach ($class_reflection->getAttributes(ODataProperty::class, \ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
                 $attributes[] = $attribute;
             }
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * Build OData-shaped attributes for a loaded model using default-selectable #[ODataProperty] metadata.
+     *
+     * Used when serializing expanded relations (e.g. MorphTo) where the concrete type is only known at runtime.
+     *
+     * @return array<string, mixed>
+     */
+    protected function getRuntimeDefaultSelectedAttributesForModel(Model $item): array
+    {
+        $attributes = [];
+        $reflectionClass = new \ReflectionClass($item);
+
+        foreach ($this->getODataPropertyAttributes($reflectionClass) as $attribute) {
+            /** @var ODataProperty $instance */
+            $instance = $attribute->newInstance();
+
+            if (! $instance->isSelectable() || ! $instance->isDefaultSelectable()) {
+                continue;
+            }
+
+            $odata_column = $instance->getName();
+            $db_column = $instance->getSource() ?? $instance->getName();
+
+            $resolver_method = 'oData'.ucfirst($instance->getName()).'Resolver';
+            if (empty($instance->getSource()) && method_exists($item, $resolver_method)) {
+                $db_column = $item->{$resolver_method}();
+            }
+
+            $attributes[$odata_column] = $item->getAttribute($db_column);
         }
 
         return $attributes;

--- a/src/Traits/AttributesTrait.php
+++ b/src/Traits/AttributesTrait.php
@@ -111,7 +111,7 @@ trait AttributesTrait
      * Child class attributes are returned last so they can override parent mappings.
      *
      * @param \ReflectionClass<object> $reflectionClass
-     * @return array<int, \ReflectionAttribute>
+     * @return array<int, \ReflectionAttribute<ODataProperty>>
      */
     protected function getODataPropertyAttributes(\ReflectionClass $reflectionClass): array
     {
@@ -308,5 +308,33 @@ trait AttributesTrait
     {
         $className ??= $this->subjectModelReflectionClass->getShortName();
         return $this->searchables[strtolower($className)] ?? [];
+    }
+
+    /**
+     * Resolve the DB attribute / column for a selectable OData property on a concrete model.
+     * Used when mapping nested $expand $select tokens for MorphTo targets, where the subject
+     * query never ran {@see handleModel} for the concrete class so {@see $selectables} may be empty.
+     *
+     * @return string|false
+     */
+    protected function getSelectableDbColumnForConcreteModel(Model $item, string $odataName): string|false
+    {
+        $reflectionClass = new \ReflectionClass($item);
+        foreach ($this->getODataPropertyAttributes($reflectionClass) as $attribute) {
+            /** @var ODataProperty $instance */
+            $instance = $attribute->newInstance();
+            if ($instance->getName() !== $odataName || ! $instance->isSelectable()) {
+                continue;
+            }
+            $db_column = $instance->getSource() ?? $instance->getName();
+            $resolver_method = 'oData'.ucfirst($instance->getName()).'Resolver';
+            if (empty($instance->getSource()) && method_exists($item, $resolver_method)) {
+                $db_column = $item->{$resolver_method}();
+            }
+
+            return is_string($db_column) ? trim($db_column) : $db_column;
+        }
+
+        return false;
     }
 }

--- a/src/Traits/ExpandTrait.php
+++ b/src/Traits/ExpandTrait.php
@@ -25,7 +25,7 @@ trait ExpandTrait
      * Apply limit to relation if it is a to-many type (HasMany, BelongsToMany, etc.).
      * Uses odata.top.default from config to prevent memory exhaustion from large collections.
      *
-     * @param Builder|Relation $query
+     * @param Builder<TModelClass>|Relation<TModelClass, TRelatedModel, Collection<int, TRelatedModel>> $query
      * @return void
      */
     private function applyExpandRelationLimit(Builder|Relation $query): void
@@ -119,37 +119,33 @@ trait ExpandTrait
      */
     private function handleExpandDetails(Builder|Relation $builder, string $details, string $relation): void
     {
-        // If $builder is a Relation, get the underlying Builder
-        if ($builder instanceof Relation) {
-            $builder = $builder->getQuery();
-        }
-
+        $relationQuery = $builder instanceof Relation ? $builder->getQuery() : $builder;
 
         // First, split the details by semicolons to separate different options
         $parsedOptions = StringUtils::getSortedDetails($details, ';');
 
         foreach ($parsedOptions as $option) {
-            $this->handleOption($builder, $option, $relation);
+            $this->handleOption($relationQuery, $option, $relation);
         }
 
         // If no $select is specified, apply default selects
         if (!collect($parsedOptions)->contains(function($option) {
             return Str::startsWith(strtolower($option), '$select=');
         })) {
-            $this->resolveToDefaultSelects($builder);
+            $this->resolveToDefaultSelects($relationQuery);
         }
     }
 
     /**
      * Handle an individual option within an expand.
      *
-     * @param Builder<TModelClass>|Relation<TModelClass, TRelatedModel, Collection<int, TRelatedModel>> $builder
+     * @param Builder<TModelClass> $builder
      * @param string  $option
      * @param string  $relation
      *
      * @return void
      */
-    private function handleOption(Builder|Relation $builder, string $option, string $relation): void
+    private function handleOption(Builder $builder, string $option, string $relation): void
     {
         // Check if the option starts with a known key
         if (Str::startsWith(strtolower($option), '$select=')) {
@@ -222,7 +218,19 @@ trait ExpandTrait
     {
         if ($this->select) {
             $this->addSelectForExpand($builder, $expandable);
-            $this->appendSelectQuery($value, $builder);
+            $tokens = [];
+            if ($value !== '') {
+                foreach (explode(',', $value) as $item) {
+                    if (! is_string($item)) {
+                        continue;
+                    }
+                    $trimmed = trim($item);
+                    if ($trimmed !== '') {
+                        $tokens[] = $trimmed;
+                    }
+                }
+            }
+            $this->nestedExpandExplicitSelectTokens[$expandable] = $tokens;
         }
     }
 

--- a/src/Traits/SelectTrait.php
+++ b/src/Traits/SelectTrait.php
@@ -2,7 +2,6 @@
 
 namespace Aqqo\OData\Traits;
 
-use Aqqo\OData\Query;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -24,6 +23,15 @@ trait SelectTrait
      * @var array<string, array<string,string>>
      */
     public array $selects = [];
+
+    /**
+     * OData property names requested per expanded relation key (e.g. relatedModel, parent)
+     * when $expand includes a nested $select=. Used at serialization with the concrete
+     * loaded model (required for MorphTo). Empty list means an explicit empty $select.
+     *
+     * @var array<string, list<string>>
+     */
+    public array $nestedExpandExplicitSelectTokens = [];
 
     /**
      * @return void

--- a/tests/Testclasses/PlainMorphTarget.php
+++ b/tests/Testclasses/PlainMorphTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Aqqo\OData\Tests\Testclasses;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Morph target with no #[ODataProperty] metadata (tests raw getAttributes fallback).
+ */
+class PlainMorphTarget extends Model
+{
+    protected $table = 'related_models';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+}

--- a/tests/Testclasses/PlainMorphTarget.php
+++ b/tests/Testclasses/PlainMorphTarget.php
@@ -5,7 +5,7 @@ namespace Aqqo\OData\Tests\Testclasses;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Morph target with no #[ODataProperty] metadata (tests raw getAttributes fallback).
+ * Morph target with no #[ODataProperty] metadata (tests whitelist-only expand: empty payload).
  */
 class PlainMorphTarget extends Model
 {

--- a/tests/Testclasses/RelatedModel.php
+++ b/tests/Testclasses/RelatedModel.php
@@ -5,6 +5,7 @@ namespace Aqqo\OData\Tests\Testclasses;
 use Aqqo\OData\Attributes\ODataProperty;
 use Aqqo\OData\Attributes\ODataRelationship;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 #[ODataProperty('cost')]
 class RelatedModel extends Model
 {
+    use HasFactory;
+
     protected $guarded = [];
 
     public $timestamps = false;

--- a/tests/Unit/ExpandTest.php
+++ b/tests/Unit/ExpandTest.php
@@ -54,6 +54,13 @@ it('can handle expand with $select option', function () {
     expect($first['relatedModel'])->toHaveKey('name');
 });
 
+it('serializes expanded relation as empty when nested $select maps to no valid fields', function () {
+    $models = createQueryFromParams(expand: 'relatedModel($select=nonExistentField)')->get();
+    $first = $models->first();
+    expect(array_key_exists('relatedModel', $first))->toEqual(true);
+    expect($first['relatedModel'])->toBe([]);
+});
+
 it('can handle expand with $filter option', function () {
     $name = $this->models->first()->name;
     $models = createQueryFromParams(expand: "relatedModel(\$filter=name eq '{$name}')")->get();

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -198,6 +198,26 @@ describe('Query', function () {
         expect($parentAttributes)->not()->toHaveKey('name');
     });
 
+    it('does not fall back to default OData projection when morph nested $select maps to no fields', function () {
+        $parent = AliasedModel::create([
+            'name' => 'Frank',
+            'full_name' => 'Frank Example',
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record',
+            'parent_type' => AliasedModel::class,
+            'parent_id' => $parent->id,
+        ]);
+
+        $request = new Request(['$expand' => 'parent($select=name)']);
+        $results = Query::for(MorphModel::class, $request)->get();
+        $parentAttributes = $results->first()['parent'];
+
+        expect($parentAttributes)->toBeArray();
+        expect($parentAttributes)->toBe([]);
+    });
+
     it('serializes morph target without OData metadata as empty whitelist-only payload', function () {
         $testModel = TestModel::factory()->create();
 
@@ -439,8 +459,9 @@ describe('Query', function () {
 it('resolves models without an ignore selects parameter', function () {
     $method = new \ReflectionMethod(Query::class, 'resolveModel');
 
-    expect($method->getNumberOfParameters())->toBe(1);
+    expect($method->getNumberOfParameters())->toBe(2);
     expect($method->getParameters()[0]->getName())->toBe('item');
+    expect($method->getParameters()[1]->getName())->toBe('expandedAsRelation');
 });
 
     it('covers all missing lines from coverage report', function () {

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -7,6 +7,7 @@ use Aqqo\OData\Tests\Testclasses\AliasedModel;
 use Aqqo\OData\Tests\Testclasses\MorphModel;
 use Aqqo\OData\Tests\Testclasses\PlainMorphTarget;
 use Aqqo\OData\Tests\Testclasses\TestModel;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
 describe('Query', function () {
@@ -243,6 +244,52 @@ describe('Query', function () {
 
         expect($parentAttributes)->toBeArray();
         expect($parentAttributes)->toBe([]);
+    });
+
+    it('caches runtime OData metadata per expanded morph target class', function () {
+        $firstParent = AliasedModel::create([
+            'name' => 'Dave',
+            'full_name' => 'Dave Example',
+        ]);
+
+        $secondParent = AliasedModel::create([
+            'name' => 'Eve',
+            'full_name' => 'Eve Example',
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record 1',
+            'parent_type' => AliasedModel::class,
+            'parent_id' => $firstParent->id,
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record 2',
+            'parent_type' => AliasedModel::class,
+            'parent_id' => $secondParent->id,
+        ]);
+
+        $request = new Request(['$expand' => 'parent']);
+        $query = new class(MorphModel::query(), request: $request) extends Query {
+            /** @var array<class-string<Model>, int> */
+            public array $runtimeDefinitionBuilds = [];
+
+            protected function buildRuntimeDefaultSelectedAttributeDefinitions(Model $item): array
+            {
+                $modelClass = $item::class;
+                $this->runtimeDefinitionBuilds[$modelClass] = ($this->runtimeDefinitionBuilds[$modelClass] ?? 0) + 1;
+
+                return parent::buildRuntimeDefaultSelectedAttributeDefinitions($item);
+            }
+        };
+
+        $results = $query->get();
+
+        expect($results)->toHaveCount(2);
+        expect($query->runtimeDefinitionBuilds)->toBe([
+            MorphModel::class => 1,
+            AliasedModel::class => 1,
+        ]);
     });
 
     it('handles queries with ordering', function () {

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -389,6 +389,13 @@ describe('Query', function () {
         expect($query->toSql())->toBeString();
     });
 
+it('resolves models without an ignore selects parameter', function () {
+    $method = new \ReflectionMethod(Query::class, 'resolveModel');
+
+    expect($method->getNumberOfParameters())->toBe(1);
+    expect($method->getParameters()[0]->getName())->toBe('item');
+});
+
     it('covers all missing lines from coverage report', function () {
         // This test specifically targets the lines mentioned in the coverage report:
         // Exception handling in get() method

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -197,7 +197,7 @@ describe('Query', function () {
         expect($parentAttributes)->not()->toHaveKey('name');
     });
 
-    it('falls back to raw attributes for morph target without OData metadata', function () {
+    it('serializes morph target without OData metadata as empty whitelist-only payload', function () {
         $testModel = TestModel::factory()->create();
 
         $parent = PlainMorphTarget::create([
@@ -218,10 +218,31 @@ describe('Query', function () {
         $parentAttributes = $results->first()['parent'];
 
         expect($parentAttributes)->toBeArray();
-        expect($parentAttributes)->toHaveKey('name');
-        expect($parentAttributes['name'])->toBe('Plain target');
-        expect($parentAttributes)->toHaveKey('full_name');
-        expect($parentAttributes['full_name'])->toBe('Plain full');
+        expect($parentAttributes)->toBe([]);
+    });
+
+    it('does not expose raw attributes for unannotated morph target even with nested $select', function () {
+        $testModel = TestModel::factory()->create();
+
+        $parent = PlainMorphTarget::create([
+            'name' => 'Plain target',
+            'full_name' => 'Plain full',
+            'cost' => 42,
+            'test_model_id' => $testModel->id,
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record',
+            'parent_type' => PlainMorphTarget::class,
+            'parent_id' => $parent->id,
+        ]);
+
+        $request = new Request(['$expand' => 'parent($select=name,full_name)']);
+        $results = Query::for(MorphModel::class, $request)->get();
+        $parentAttributes = $results->first()['parent'];
+
+        expect($parentAttributes)->toBeArray();
+        expect($parentAttributes)->toBe([]);
     });
 
     it('handles queries with ordering', function () {

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -5,6 +5,7 @@ namespace Aqqo\OData\Tests\Unit;
 use Aqqo\OData\Query;
 use Aqqo\OData\Tests\Testclasses\AliasedModel;
 use Aqqo\OData\Tests\Testclasses\MorphModel;
+use Aqqo\OData\Tests\Testclasses\PlainMorphTarget;
 use Aqqo\OData\Tests\Testclasses\TestModel;
 use Illuminate\Http\Request;
 
@@ -151,7 +152,7 @@ describe('Query', function () {
         expect($first)->not()->toHaveKey('full_name');
     });
 
-    it('uses getAttributes when selects are ignored for relations', function () {
+    it('uses default OData projection for morph expanded relations', function () {
         $parent = AliasedModel::create([
             'name' => 'Bob',
             'full_name' => 'Bob Example',
@@ -168,9 +169,59 @@ describe('Query', function () {
         $parentAttributes = $results->first()['parent'];
 
         expect($parentAttributes)->toBeArray();
+        expect($parentAttributes)->toHaveKey('display_name');
+        expect($parentAttributes['display_name'])->toBe('BOB EXAMPLE');
+        expect($parentAttributes)->not()->toHaveKey('full_name');
+    });
+
+    it('applies nested select on morph expanded relation', function () {
+        $parent = AliasedModel::create([
+            'name' => 'Carol',
+            'full_name' => 'Carol Example',
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record',
+            'parent_type' => AliasedModel::class,
+            'parent_id' => $parent->id,
+        ]);
+
+        $request = new Request(['$expand' => 'parent($select=display_name)']);
+        $results = Query::for(MorphModel::class, $request)->get();
+        $parentAttributes = $results->first()['parent'];
+
+        expect($parentAttributes)->toBeArray();
+        expect($parentAttributes)->toHaveKeys(['display_name']);
+        expect($parentAttributes['display_name'])->toBe('CAROL EXAMPLE');
+        expect($parentAttributes)->not()->toHaveKey('full_name');
+        expect($parentAttributes)->not()->toHaveKey('name');
+    });
+
+    it('falls back to raw attributes for morph target without OData metadata', function () {
+        $testModel = TestModel::factory()->create();
+
+        $parent = PlainMorphTarget::create([
+            'name' => 'Plain target',
+            'full_name' => 'Plain full',
+            'cost' => 42,
+            'test_model_id' => $testModel->id,
+        ]);
+
+        MorphModel::create([
+            'name' => 'Morph record',
+            'parent_type' => PlainMorphTarget::class,
+            'parent_id' => $parent->id,
+        ]);
+
+        $request = new Request(['$expand' => 'parent']);
+        $results = Query::for(MorphModel::class, $request)->get();
+        $parentAttributes = $results->first()['parent'];
+
+        expect($parentAttributes)->toBeArray();
+        expect($parentAttributes)->toHaveKey('name');
+        expect($parentAttributes['name'])->toBe('Plain target');
         expect($parentAttributes)->toHaveKey('full_name');
-        expect($parentAttributes['full_name'])->toBe('Bob Example');
-        expect($parentAttributes)->not()->toHaveKey('display_name');
+        expect($parentAttributes['full_name'])->toBe('Plain full');
     });
 
     it('handles queries with ordering', function () {
@@ -319,9 +370,9 @@ describe('Query', function () {
 
     it('covers all missing lines from coverage report', function () {
         // This test specifically targets the lines mentioned in the coverage report:
-        // Lines 162-163: Exception handling in get() method
-        // Line 190: resolveModel with ignore_selects=true
-        // Line 205: MorphTo relationship handling
+        // Exception handling in get() method
+        // resolveModel with runtime OData fallback (MorphTo / ignore_selects path)
+        // MorphTo relationship handling
         
         // Test 1: Exception handling (lines 162-163)
         $mockBuilder = \Mockery::mock(\Illuminate\Database\Eloquent\Builder::class);


### PR DESCRIPTION
## Summary

Runtime OData serialization for expanded **MorphTo** (and similar) relations: honor nested `$select` when present, otherwise default-selectable `#[ODataProperty]` fields. Models **without** OData metadata serialize as an **empty** object for that expanded node — **not** raw database attributes (whitelist-only expand).

## Changes

- **Query**: `resolveAttributesWithRuntimeODataFallback()` returns an empty array when there are no nested select keys and no default-selectable metadata, instead of falling back to `getAttributes()`.
- **AttributesTrait**: clarify that callers on the expand path must not assume a raw-attribute fallback.
- **Tests**: morph default projection and nested `$select`; plain morph target and nested `$select` on unannotated target expect an empty payload.
- **RelatedModel**: `HasFactory` plus `RelatedModelFactory` so `SelectTraitTest` and the full Pest suite can use `RelatedModel::factory()` (aligned with `Testcase` factory name guessing).

## Notes

Consumers can use `Aqqo\OData\Query` directly once this package version is required, without an app-specific `MorphAwareQuery`.

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Expanded relations now always serialize via a selectable-field whitelist with a runtime fallback; nested $select inside $expand is honored. Expanded relations (including polymorphic targets) no longer expose raw DB attributes and may return an empty array when no selectable fields apply.

* **Tests**
  * Added/updated tests for morph expansion, nested $select behavior, runtime fallback, caching of runtime metadata, and empty-expanded-payload cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->